### PR TITLE
Fixes for Issue #1

### DIFF
--- a/Outlines/Scripts/RendererFeatures/ScreenSpaceOutlines.cs
+++ b/Outlines/Scripts/RendererFeatures/ScreenSpaceOutlines.cs
@@ -40,7 +40,7 @@ public class ScreenSpaceOutlines : ScriptableRendererFeature {
         public RenderTextureFormat colorFormat;
         public int depthBufferBits = 16;
         public FilterMode filterMode;
-        public Color backgroundColor;
+        public Color backgroundColor = Color.black;
 
         [Header("View Space Normal Texture Object Draw Settings")]
         public PerObjectData perObjectData;
@@ -78,7 +78,7 @@ public class ScreenSpaceOutlines : ScriptableRendererFeature {
             normalsMaterial = new Material(Shader.Find("Hidden/ViewSpaceNormals"));
 
             occludersMaterial = new Material(Shader.Find("Hidden/UnlitColor"));
-            occludersMaterial.SetColor("_Color,", normalsTextureSettings.backgroundColor);
+            occludersMaterial.SetColor("_Color", normalsTextureSettings.backgroundColor);
         }
 
         public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor) {
@@ -178,12 +178,12 @@ public class ScreenSpaceOutlines : ScriptableRendererFeature {
 
     }
 
-    [SerializeField] private RenderPassEvent renderPassEvent;
+    [SerializeField] private RenderPassEvent renderPassEvent = RenderPassEvent.AfterRenderingOpaques;
     [SerializeField] private LayerMask outlinesLayerMask;
     [SerializeField] private LayerMask outlinesOccluderLayerMask;
     
-    [SerializeField] private ScreenSpaceOutlineSettings outlineSettings;
-    [SerializeField] private ViewSpaceNormalsTextureSettings viewSpaceNormalsTextureSettings;
+    [SerializeField] private ScreenSpaceOutlineSettings outlineSettings = new ScreenSpaceOutlineSettings();
+    [SerializeField] private ViewSpaceNormalsTextureSettings viewSpaceNormalsTextureSettings = new ViewSpaceNormalsTextureSettings();
 
     private ViewSpaceNormalsTexturePass viewSpaceNormalsTexturePass;
     private ScreenSpaceOutlinePass screenSpaceOutlinePass;


### PR DESCRIPTION
Line 43: By default the background color had an alpha of 0. Occluder would not work and needs an alpha of 1
Line 81: Typo in "_Color" was "_Color,"
Line 181: By default the RenderPass is set to "Before Rendering Pre Passes", to me it works only if it sets at minimum "After rendering Opaques"
Line 185 & 186: Without this, the render feature throw errors as the settings are not created beforehand.