### PR TITLE
Fixed wrapping issue when Outline is at screen boundary

### DIFF
--- a/Outlines/Scripts/RendererFeatures/ScreenSpaceOutlines.cs
+++ b/Outlines/Scripts/RendererFeatures/ScreenSpaceOutlines.cs
@@ -93,7 +93,7 @@ public class ScreenSpaceOutlines : ScriptableRendererFeature {
             RenderTextureDescriptor textureDescriptor = renderingData.cameraData.cameraTargetDescriptor;
             textureDescriptor.colorFormat = settings.colorFormat;
             textureDescriptor.depthBufferBits = settings.depthBufferBits;
-            RenderingUtils.ReAllocateIfNeeded(ref normals, textureDescriptor, settings.filterMode);
+            RenderingUtils.ReAllocateIfNeeded(ref normals, textureDescriptor, settings.filterMode, wrapMode:TextureWrapMode.Clamp);
             
             // Color Buffer
             textureDescriptor.depthBufferBits = 0;


### PR DESCRIPTION
Clamping UVs in order to mitigate wraparound effect, where Outlines at the top of the screen also show up at the bottom and vice versa as well as for left and right.

### Tested in

- Unity 2023.2.191
- DX11
- Universal Render Pipeline

### Before this PR: 

The outline (white in my example) around the cube touches the screen on the right and left side. Because the UVs have the outline width added and subtracted, some UVs will have negative values in the bottom and left, and some will have values above 1 at the top and right.  This results in a wraparound when sampling the Normal Texture, and in the end results in Outlines showing up at the opposing screen border:

Before this commit, the Normal sampled for +1/+1 UVs looked like this. Note the blue line at the top right.
![image](https://github.com/user-attachments/assets/b664b26c-210f-4299-b4a5-82bb128e3bac)

And the Outline like this:

![image](https://github.com/user-attachments/assets/667d2c3a-18fa-47f0-848e-dcf0495c1dd3)

### Changes in this PR:

Setting `wrapMode: TextureWrapMode.Clamp` when allocating Normals texture.

### After this PR:

After setting the clamping mode for the normals texture (clamping the UVs) this wraparound is fixed. Normals:

![image](https://github.com/user-attachments/assets/89beafee-61a3-4f24-9138-a69030a60e8e)

And the Outline after the patch:

![image](https://github.com/user-attachments/assets/bcc5bfd1-54b4-4ee5-8383-2b71f7b15daa)

### Unintentional side-effect:

The Outline is no longer drawn along the screen border. Note the bottom-right corner on the before and after images. But I personally think that's better anyways.

