### PR TITLE
Fix render target transparency not working with outlines

### DIFF
--- a/Outlines/ShaderGraphs/Outlines.shadergraph
+++ b/Outlines/ShaderGraphs/Outlines.shadergraph
@@ -254,6 +254,12 @@
         },
         {
             "m_Id": "bfbc606cd2b143f3ac028f6aa2427e69"
+        },
+        {
+            "m_Id": "4422f9fa1638418c827ce68b4a98cf56"
+        },
+        {
+            "m_Id": "4b98dc0fed774ae2ac93d17b8297e594"
         }
     ],
     "m_GroupDatas": [],
@@ -500,6 +506,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "4422f9fa1638418c827ce68b4a98cf56"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "58c20edf5afd4026a68cff8b4d531679"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "47259074f9034922ace0f38781793dfc"
                 },
                 "m_SlotId": 2
@@ -565,6 +585,20 @@
                     "m_Id": "522ec5ff9e3b424d90a58215565e776e"
                 },
                 "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "4b98dc0fed774ae2ac93d17b8297e594"
+                },
+                "m_SlotId": 4
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "4422f9fa1638418c827ce68b4a98cf56"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -1262,6 +1296,20 @@
             },
             "m_InputSlot": {
                 "m_Node": {
+                    "m_Id": "4422f9fa1638418c827ce68b4a98cf56"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9fa9ba28d1804c1fb9b3d8fbdec08310"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
                     "m_Id": "bfbc606cd2b143f3ac028f6aa2427e69"
                 },
                 "m_SlotId": 3
@@ -1293,6 +1341,20 @@
                     "m_Id": "d6cf6a6fd306481683cfe39b390f9c76"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "af080a8ede6f41c0bf2bf29667cbcbd3"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "4b98dc0fed774ae2ac93d17b8297e594"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -3844,6 +3906,49 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "4422f9fa1638418c827ce68b4a98cf56",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 2396.0,
+            "y": -1270.0,
+            "width": 209.33349609375,
+            "height": 304.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "59285132050b40f3befb735e43cfae9e"
+        },
+        {
+            "m_Id": "6fdde412ac624337b5a750eddf139195"
+        },
+        {
+            "m_Id": "66f0dba7deb0467aa7890b1428a58b0b"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "445dd079ca0447168b49c75ab3acb0cb",
     "m_Id": 0,
@@ -3994,6 +4099,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "49a605a9c37948f5a20a3a9ca4667621",
+    "m_Id": 4,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
     "m_ObjectId": "4a32f6103b2441ab91b6561e4d7e05d0",
     "m_Group": {
@@ -4087,6 +4207,53 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SplitNode",
+    "m_ObjectId": "4b98dc0fed774ae2ac93d17b8297e594",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Split",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 2252.666748046875,
+            "y": -1440.0001220703125,
+            "width": 120.666748046875,
+            "height": 150.666748046875
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "737e9caecb4140faafb1f12cf7bbb0e0"
+        },
+        {
+            "m_Id": "fc52526661d1426dad6402195ea900b3"
+        },
+        {
+            "m_Id": "dfdf5b541d2f4f5eb271dafe73750ce6"
+        },
+        {
+            "m_Id": "8551ab9311864960871d74b779f296ab"
+        },
+        {
+            "m_Id": "49a605a9c37948f5a20a3a9ca4667621"
+        }
+    ],
+    "synonyms": [
+        "separate"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -4746,6 +4913,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "59285132050b40f3befb735e43cfae9e",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "59338eaac4164e14b062cd33cfc1dcb6",
     "m_Id": 5,
@@ -5205,6 +5396,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "66f0dba7deb0467aa7890b1428a58b0b",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "6861cce6b2454bdf998810859a32f0eb",
     "m_Id": 0,
@@ -5568,6 +5783,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6fdde412ac624337b5a750eddf139195",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "6ff2fd629e8b40abaa4f5d8969fc99d8",
     "m_Id": 1,
     "m_DisplayName": "B",
@@ -5767,6 +6006,30 @@
     "m_StageCapability": 3,
     "m_Value": {
         "x": 1.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "737e9caecb4140faafb1f12cf7bbb0e0",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
         "y": 0.0,
         "z": 0.0,
         "w": 0.0
@@ -6283,6 +6546,21 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8551ab9311864960871d74b779f296ab",
+    "m_Id": 3,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -9574,6 +9852,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "dfdf5b541d2f4f5eb271dafe73750ce6",
+    "m_Id": 2,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "e18ae5ffad314d32a082f98a90916504",
     "m_Id": 1,
@@ -10471,6 +10764,21 @@
         "z": 0.0,
         "w": 0.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "fc52526661d1426dad6402195ea900b3",
+    "m_Id": 1,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {


### PR DESCRIPTION
### Problem and Source:
I had a camera that rendered a single object to a Render Targetm with RGBA channels. A Raw Image would then render this Render Target to it.
<img width="271" height="262" alt="image" src="https://github.com/user-attachments/assets/6d39b8e8-3c7d-4b87-8bf3-2df56f7ebfe2" />

However when using the Outline effect, no matter what settings were changed in the effect and URP pipeline, it would generally render the Camera's clear color in the background, even if the alpha was 0. Changing depth information would render the effects background color, even if it had an alpha of 0.
<img width="266" height="262" alt="image" src="https://github.com/user-attachments/assets/76e346da-af97-4cd9-9ba0-6b9af1443c15" />
The camera has to render a clear color. If it renders the skybox, the skybox is rendered. If the background is uninitialised the default behaviour is to render on top of non-existing pixels leading to ghosting effects on the RT.

This was a fix for my own very specific use case, however I don't think it negatively affects the function of any other parts of the tool, as far as I've tested. I also believe it may answer the Issue #7 

### Fix:
The fix is to add the alpha value of the URP Sample Buffer (BlitSource) to the final Opacity value in Outline.shadergraph
<img width="630" height="569" alt="image" src="https://github.com/user-attachments/assets/207548fd-12fa-4c95-bbda-118cc4e9220d" />

### Result:
The result is that Render Targets rendered from a camera, can now use the outline effect and still render to Render Targets with a transparent background.
<img width="247" height="272" alt="image" src="https://github.com/user-attachments/assets/0825d29a-ff0a-48dc-a13f-2c6a9c500583" />


### Remarks:
Depending on the Render Targets resolution, a thin line of the camera clear color may still appear
<img width="450" height="364" alt="image" src="https://github.com/user-attachments/assets/e3ad148b-1525-46d6-970f-fd3482571441" />
Just make the camera's clear color the same as the outline color and it is not noticeable.

### Personal Comments:
I apologise if this is not an issue or is irrelevant to the repo. This is my first contribution I've made to a public repo, and I'm mostly doing it just because I had a specific issue with the plugin.
I also realise that the repo is no longer active, however on the off chance someone may need this solution I would like to open this for consideration or just in case someone was doing what I did which was searching the issues and PR's to see if there was a solution.

